### PR TITLE
Fixing indexing and text offset problems in injectCFIMarkerIntoText.

### DIFF
--- a/src/epub_cfi/cfi_instructions.js
+++ b/src/epub_cfi/cfi_instructions.js
@@ -145,20 +145,21 @@ EPUBcfi.CFIInstructions = {
 
 		var nodeNum;
 		var currNodeLength;
+		var currNodeMaxIndex = 0;
 		var currTextPosition = 0;
 		var nodeOffset;
 		var originalText;
 		var $injectedNode;
 		var $newTextNode;
 		// The iteration counter may be incorrect here (should be $textNodeList.length - 1 ??)
-		for (nodeNum = 0; nodeNum <= $textNodeList.length; nodeNum++) {
+		for (nodeNum = 0; nodeNum < $textNodeList.length; nodeNum++) {
 
 			if ($textNodeList[nodeNum].nodeType === 3) {
 
-				currNodeMaxIndex = ($textNodeList[nodeNum].nodeValue.length - 1) + currTextPosition;
+				currNodeMaxIndex = $textNodeList[nodeNum].nodeValue.length + currTextPosition;
 				nodeOffset = textOffset - currTextPosition;
 
-				if (currNodeMaxIndex >= textOffset) {
+				if (currNodeMaxIndex > textOffset) {
 
 					// This node is going to be split and the components re-inserted
 					originalText = $textNodeList[nodeNum].nodeValue;	
@@ -175,9 +176,13 @@ EPUBcfi.CFIInstructions = {
 
 					return $textNodeList.parent();
 				}
+				else if (currNodeMaxIndex == textOffset) {
+					//the node should be injected directly after the complete text node
+					$injectedNode = $(elementToInject).insertAfter($textNodeList.eq(nodeNum));
+					return $textNodeList.parent();
+				}
 				else {
-
-					currTextPosition = currTextPosition + currNodeMaxIndex;
+					currTextPosition = currNodeMaxIndex;
 				}
 			}
 		}


### PR DESCRIPTION
This change fixes a couple of situations where injectCFIMarkerIntoText would index into the text node list or calculate offsets into text incorrectly. It also makes the method more CFI spec compliant by allowing for injection after the last character of a text node.
