### PR TITLE
Fix for char offset range component generation edge case.

### DIFF
--- a/spec/javascripts/models/cfi_generation_spec.js
+++ b/spec/javascripts/models/cfi_generation_spec.js
@@ -72,6 +72,29 @@ describe("CFI GENERATOR", function () {
             expect(generatedCFI).toEqual("/4/2[startParent],/2,/3:1");
         });
 
+        it("can generate a range component between a text node in an element node and a text node with the same parent", function () {
+  
+          var dom =
+            "<html>"
+              +    "<div></div>"
+              +    "<div>"
+              +         "<div id='startParent'>"
+              +             "textnode0"
+              +             "<div id='startElement'>textnode1</div>"
+              +             "textnode2"
+              +             "<div></div>"
+              +         "</div>"
+              +     "</div>"
+              +     "<div></div>"
+              + "</html>";
+          var $dom = $((new window.DOMParser).parseFromString(dom, "text/xml"));
+  
+          var $startElement1 = $($('#startElement', $dom).contents()[0]);
+          var $startElement2 = $($('#startParent', $dom).contents()[2]);
+          var generatedCFI = EPUBcfi.Generator.generateRangeComponent($startElement1[0], 4, $startElement2[0], 4);
+          expect(generatedCFI).toEqual("/4/2[startParent],/2[startElement]/1:4,/3:4");
+        });
+      
         it("can generate a range component between an element node and a text node with different parents", function () {
 
             var dom = 

--- a/src/models/cfi_generator.js
+++ b/src/models/cfi_generator.js
@@ -8,6 +8,8 @@ EPUBcfi.Generator = {
 
         var docRange;
         var commonAncestor;
+        var $rangeStartParent;
+        var $rangeEndParent;
         var range1OffsetStep;
         var range1CFI;
         var range2OffsetStep;
@@ -34,11 +36,23 @@ EPUBcfi.Generator = {
 
             // Generate terminating offset and range 1
             range1OffsetStep = this.createCFITextNodeStep($(rangeStartElement), startOffset, classBlacklist, elementBlacklist, idBlacklist);
-            range1CFI = this.createCFIElementSteps($(rangeStartElement).parent(), commonAncestor, classBlacklist, elementBlacklist, idBlacklist) + range1OffsetStep;
+            $rangeStartParent = $(rangeStartElement).parent();
+            if ($rangeStartParent[0] === commonAncestor) {
+              // rangeStartElement is a text child node of the commonAncestor, so it's CFI sub-path is only the text node step:
+              range1CFI = range1OffsetStep;
+            } else {
+              range1CFI = this.createCFIElementSteps($rangeStartParent, commonAncestor, classBlacklist, elementBlacklist, idBlacklist) + range1OffsetStep;
+            }
 
             // Generate terminating offset and range 2
             range2OffsetStep = this.createCFITextNodeStep($(rangeEndElement), endOffset, classBlacklist, elementBlacklist, idBlacklist);
-            range2CFI = this.createCFIElementSteps($(rangeEndElement).parent(), commonAncestor, classBlacklist, elementBlacklist, idBlacklist) + range2OffsetStep;
+            $rangeEndParent = $(rangeEndElement).parent();
+            if ($rangeEndParent[0] === commonAncestor) {
+              // rangeEndElement is a text child node of the commonAncestor, so it's CFI sub-path is only the text node step:
+              range2CFI = range2OffsetStep;
+            } else {
+              range2CFI = this.createCFIElementSteps($rangeEndParent, commonAncestor, classBlacklist, elementBlacklist, idBlacklist) + range2OffsetStep;
+            }
 
             // Generate shared component
             commonCFIComponent = this.createCFIElementSteps($(commonAncestor), "html", classBlacklist, elementBlacklist, idBlacklist);


### PR DESCRIPTION
This fixes generating a range component between a text node in an element node and a text node with the same parent as the element node.