### PR TITLE
Replace all global document property references.

### DIFF
--- a/src/models/cfi_generator.js
+++ b/src/models/cfi_generator.js
@@ -5,6 +5,7 @@ EPUBcfi.Generator = {
     // ------------------------------------------------------------------------------------ //
 
     generateCharOffsetRangeComponent : function (rangeStartElement, startOffset, rangeEndElement, endOffset, classBlacklist, elementBlacklist, idBlacklist) {
+        var document = rangeStartElement.ownerDocument;
 
         var docRange;
         var commonAncestor;
@@ -49,6 +50,7 @@ EPUBcfi.Generator = {
     },
 
     generateElementRangeComponent : function (rangeStartElement, rangeEndElement, classBlacklist, elementBlacklist, idBlacklist) {
+        var document = rangeStartElement.ownerDocument;
 
         var docRange;
         var commonAncestor;
@@ -83,6 +85,8 @@ EPUBcfi.Generator = {
     },
 
     generateRangeComponent : function (rangeStartElement, startOffset, rangeEndElement, endOffset, classBlacklist, elementBlacklist, idBlacklist) {
+        var document = rangeStartElement.ownerDocument;
+
         if(rangeStartElement.nodeType === Node.ELEMENT_NODE && rangeEndElement.nodeType === Node.ELEMENT_NODE){
             return this.generateElementRangeComponent(rangeStartElement, rangeEndElement, classBlacklist, elementBlacklist, idBlacklist);
         } else if(rangeStartElement.nodeType === Node.TEXT_NODE && rangeEndElement.nodeType === Node.TEXT_NODE){

--- a/src/models/cfi_instructions.js
+++ b/src/models/cfi_instructions.js
@@ -144,6 +144,7 @@ EPUBcfi.CFIInstructions = {
 	//   is required. This is obtained with the jquery parent() method. An alternative would be to 
 	//   pass in the parent with a filtered list containing only children that are part of the target text node.
     injectCFIMarkerIntoText : function ($textNodeList, textOffset, elementToInject) {
+        var document = $textNodeList[0].ownerDocument;
 
         var nodeNum;
         var currNodeLength;


### PR DESCRIPTION
This fixes WRONG_DOCUMENT_ERR we encountered when creating a range on a Hudl 1 device, which happens when an Epub is displayed inside of an iframe.

Could not create a failing test for Chrome though.

Replacing global document with element.ownerDocument might not be
required in all cases, but better to be on the safe side.

Related to #8.