### PR TITLE
Fix marker injection with comments and processing instructions nodes

### DIFF
--- a/spec/javascripts/models/cfi_instruction_spec.js
+++ b/spec/javascripts/models/cfi_instruction_spec.js
@@ -142,6 +142,19 @@ describe("CFI INSTRUCTION OBJECT", function () {
 		expect($result[2].nodeValue).toEqual("text3");
 	});
 
+	it('returns the correct text node if it start with a processing instruction node', function () {
+
+		var domParser = new window.DOMParser();
+		var xhtml = '<div><?xml-stylesheet type="text/css" href="style.css"?>text</div>';
+		var doc = domParser.parseFromString(xhtml, 'text/xml');
+		var $currentNode = $(doc.firstChild);
+
+		var $result = EPUBcfi.CFIInstructions.getNextNode(1, $currentNode, ["cfiMarker"], []);
+		expect($result.length).toEqual(2);
+		expect($result[0].nodeValue).toEqual("type=\"text/css\" href=\"style.css\"");
+		expect($result[1].nodeValue).toEqual("text");
+	});
+
 	it('returns the correct text node if the node is in the first position of a set of child nodes', function () {
 
 		var domParser = new window.DOMParser();

--- a/spec/javascripts/models/cfi_interpreter_spec.js
+++ b/spec/javascripts/models/cfi_interpreter_spec.js
@@ -36,6 +36,97 @@ describe('CFI INTERPRETER OBJECT', function () {
         expect($injectedElement.parent().attr("id")).toBe(expectedResult);
     });
 
+    it('can inject into a node containing comments', function () {
+        var dom = 
+            "<html>"
+            +    "<div></div>"
+            +    "<div>"
+            +         "<div id='startParent'>"
+            +             "<!-- comment -->" // size=16
+            +             "text1 text2 text3"
+            +         "</div>"
+            +     "</div>"
+            +     "<div></div>"
+            + "</html>";
+
+        var $dom = $((new window.DOMParser).parseFromString(dom, "text/xml"));         
+
+        var CFI = "epubcfi(/6/14!/4/2[startParent],/1:22,/1:27)";
+
+        var rangeInfo = EPUBcfi.Interpreter.injectRangeElements(
+            CFI, 
+            $dom, 
+            "<span id='start' class='cfi-marker'></span>", 
+            "<span id='end' class='cfi-marker'></span>",
+            ["cfi-marker"]
+            );
+
+        var result = $($($($dom.contents()).contents()[1]).contents()).contents()[3];
+        expect(result.data).toEqual("text2");
+
+    });
+
+    it('can inject into a node containing processing instructions', function () {
+        var dom = 
+            "<html>"
+            +    "<div></div>"
+            +    "<div>"
+            +         "<div id='startParent'>"
+            +             "<?xml-stylesheet type='text/css' href='style.css'?>" // size=51
+            +             "text1 text2 text3"
+            +         "</div>"
+            +     "</div>"
+            +     "<div></div>"
+            + "</html>";
+
+        var $dom = $((new window.DOMParser).parseFromString(dom, "text/xml"));         
+
+        var CFI = "epubcfi(/6/14!/4/2[startParent],/1:57,/1:62)";
+
+        var rangeInfo = EPUBcfi.Interpreter.injectRangeElements(
+            CFI, 
+            $dom, 
+            "<span id='start' class='cfi-marker'></span>", 
+            "<span id='end' class='cfi-marker'></span>",
+            ["cfi-marker"]
+            );
+
+        var result = $($($($dom.contents()).contents()[1]).contents()).contents()[3];
+        expect(result.data).toEqual("text2");
+
+    });
+
+    it('can inject into a node containing processing instructions and comments', function () {
+        var dom = 
+            "<html>"
+            +    "<div></div>"
+            +    "<div>"
+            +         "<div id='startParent'>"
+            +             "<?xml-stylesheet type='text/css' href='style.css'?>" // size=51
+            +             "<!-- comment -->" // size=16
+            +             "text1 text2 text3"
+            +         "</div>"
+            +     "</div>"
+            +     "<div></div>"
+            + "</html>";
+
+        var $dom = $((new window.DOMParser).parseFromString(dom, "text/xml"));         
+
+        var CFI = "epubcfi(/6/14!/4/2[startParent],/1:73,/1:78)";
+
+        var rangeInfo = EPUBcfi.Interpreter.injectRangeElements(
+            CFI, 
+            $dom, 
+            "<span id='start' class='cfi-marker'></span>", 
+            "<span id='end' class='cfi-marker'></span>",
+            ["cfi-marker"]
+            );
+
+        var result = $($($($dom.contents()).contents()[1]).contents()).contents()[4];
+
+        expect(result.data).toEqual("text2");
+    });
+
     it('can inject into previously injected text node (dmitry)', function () {
         var dom = 
             "<html>"

--- a/src/models/cfi_generator.js
+++ b/src/models/cfi_generator.js
@@ -314,13 +314,13 @@ EPUBcfi.Generator = {
                     textNodeOnlyIndex = textNodeOnlyIndex + 1;
                 } else if (this.nodeType === Node.COMMENT_NODE) {
                     prevNodeWasTextNode = true;
-                    characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.length + 7; // <!--[comment]-->
+                    characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.length + 7; // 7 is the size of the html comment tag <!--[comment]-->
                     if (indexOfFirstInSequence === undefined) {
                         indexOfFirstInSequence = textNodeOnlyIndex;
                     }
                 } else if (this.nodeType === Node.PROCESSING_INSTRUCTION_NODE) {
                     prevNodeWasTextNode = true;
-                    characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.data.length + this.target.length + 5; // <?[target] [data]?>
+                    characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.data.length + this.target.length + 5; // 5 is the size of the instruction processing tag including the required space between the target and the data <?[target] [data]?>
                     if (indexOfFirstInSequence === undefined) {
                         indexOfFirstInSequence = textNodeOnlyIndex;
                     }
@@ -332,9 +332,9 @@ EPUBcfi.Generator = {
                 indexOfFirstInSequence = undefined;
                 characterOffsetSinceUnsplit  = 0;
             } else if (this.nodeType === Node.COMMENT_NODE) {
-                characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.length + 7;
+                characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.length + 7; // <!--[comment]-->
             } else if (this.nodeType === Node.PROCESSING_INSTRUCTION_NODE) {
-                characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.data.length + this.target.length + 5;
+                characterOffsetSinceUnsplit = characterOffsetSinceUnsplit + this.data.length + this.target.length + 5; // <?[target] [data]?>
             }
         });
 

--- a/src/models/cfi_instructions.js
+++ b/src/models/cfi_instructions.js
@@ -155,7 +155,7 @@ EPUBcfi.CFIInstructions = {
         // The iteration counter may be incorrect here (should be $textNodeList.length - 1 ??)
         for (nodeNum = 0; nodeNum <= $textNodeList.length; nodeNum++) {
 
-            if ($textNodeList[nodeNum].nodeType === 3) {
+            if ($textNodeList[nodeNum].nodeType === Node.TEXT_NODE) {
 
                 currNodeMaxIndex = $textNodeList[nodeNum].nodeValue.length  + currTextPosition;
                 nodeOffset = textOffset - currTextPosition;
@@ -181,9 +181,14 @@ EPUBcfi.CFIInstructions = {
                     return $injectedNode;
                 }
                 else {
-
                     currTextPosition = currNodeMaxIndex;
                 }
+            } else if($textNodeList[nodeNum].nodeType === Node.COMMENT_NODE){
+            	currNodeMaxIndex = $textNodeList[nodeNum].nodeValue.length + 7 + currTextPosition;
+                currTextPosition = currNodeMaxIndex;
+            } else if($textNodeList[nodeNum].nodeType === Node.PROCESSING_INSTRUCTION_NODE){
+            	currNodeMaxIndex = $textNodeList[nodeNum].nodeValue.length + $textNodeList[nodeNum].target.length + 5
+                currTextPosition = currNodeMaxIndex;
             }
         }
 


### PR DESCRIPTION
When a text node contains comments or processing instruction, it was not possible to inject markers in it.