### PR TITLE
cfi_instructions.js: wrong variable name in thrown exception

### DIFF
--- a/src/models/cfi_instructions.js
+++ b/src/models/cfi_instructions.js
@@ -258,7 +258,7 @@ EPUBcfi.CFIInstructions = {
 		// The filtering above should have counted the number of "logical" text nodes; this can be used to 
 		// detect out of range errors
 		if ($targetTextNodeList.length === 0) {
-			throw EPUBcfi.OutOfRangeError(logicalTargetTextNodeIndex, currLogicalTextNodeIndex, "Index out of range");
+			throw EPUBcfi.OutOfRangeError(targetLogicalTextNodeIndex, currLogicalTextNodeIndex, "Index out of range");
 		}
 
 		// return the text node list


### PR DESCRIPTION
logicalTargetTextNodeIndex -> targetLogicalTextNodeIndex