### PR TITLE
Allow user specified rjs wrappers.

### DIFF
--- a/readium-build-tools/RequireJS_config.js
+++ b/readium-build-tools/RequireJS_config.js
@@ -321,7 +321,8 @@ function(thiz){
 
     //findNestedDependencies: true,
 
-    wrap: false,
+    // Allows users to specify a wrapper. Any value here takes precedence.
+    // wrap: false,
 
     wrapShim: false,
 


### PR DESCRIPTION
* Because of precedence rules any option set in later configs ends up
  overrided by this config. Since the wrapper is set to the default
  value of false anyway, removing it lets users up the build chain
  set their own wrapper.
* This looks like the cleanest way to let a user supply a custom a wrapper when including this library but still working within the build process that was setup. Other suggestions are welcome.