### PR TITLE
Fix version of node module cpy

### DIFF
--- a/package.cson
+++ b/package.cson
@@ -130,7 +130,7 @@ devDependencies:
 
     "rimraf": 'latest'
 
-    "cpy": 'latest'
+    "cpy": '3.4.1'
     "ncp": 'latest'
 
     "mkdirp": 'latest'

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "karma-sauce-launcher": "latest",
     "cson": "latest",
     "rimraf": "latest",
-    "cpy": "latest",
+    "cpy": "3.4.1",
     "ncp": "latest",
     "mkdirp": "latest",
     "watch": "latest",


### PR DESCRIPTION
Latest version of module [cpy](https://www.npmjs.com/package/cpy) doesn't include ```cli.js```. It is now a separate module named [cpy-cli](https://www.npmjs.com/package/cpy).

So I fixed the version of cpy to **3.4.1**, the latest before the split.

```cpy/cli.js``` is used to copy files during the build : https://github.com/readium/readium-cfi-js/blob/master/readium-build-tools/optimizePackageJsonScripts.js#L17