### PR TITLE
Set explicit jquery version number due to bug in 'latest' (2.2.0).

### DIFF
--- a/package.cson
+++ b/package.cson
@@ -109,7 +109,7 @@ devDependencies:
 
     "almond": 'latest'
 
-    "jquery": 'latest'
+    "jquery": '2.1.4'
 
 
     "pegjs": 'latest'

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "requirejs": "latest",
     "almond": "latest",
-    "jquery": "latest",
+    "jquery": "2.1.4",
     "pegjs": "latest",
     "karma": "latest",
     "karma-chrome-launcher": "latest",


### PR DESCRIPTION
This will explicitly set the jquery version to the latest where ['ScrollView::getPageViewRange'](https://github.com/readium/readium-shared-js/blob/master/js/views/scroll_view.js#L1081) works as intended. The jquery method 'position()' returns the wrong position relative to the parent, this leads to a bug where 'ReaderView::openPageNext()' does not work if the next page is a new chapter. This is only reproducible in scroll view (ReadiumSDK.Views.ReaderView.VIEW_TYPE_SCROLLED_DOC).

This bug is also reproducible in the [demo viewer](http://readium.github.io/readium-js-viewer/).