### PR TITLE
Fix Issue #39:  CFI Generation fails with namespaced tags.

### DIFF
--- a/js/cfi_API.js
+++ b/js/cfi_API.js
@@ -93,6 +93,13 @@ var init = function(cfiParser, cfiInterpreter, cfiInstructions, cfiRuntimeErrors
         },
         injectElementAtOffset : function ($textNodeList, textOffset, elementToInject) {
             return cfiInstructions.injectCFIMarkerIntoText($textNodeList, textOffset, elementToInject);
+        },
+        _matchesLocalNameOrElement: function (element, otherNameOrElement) {
+            if (typeof otherNameOrElement === 'string') {
+                return element.localName === otherNameOrElement;
+            } else {
+                return element.isSameNode(otherNameOrElement);
+            }
         }
     };
 

--- a/js/cfi_generator.js
+++ b/js/cfi_generator.js
@@ -13,6 +13,8 @@
 
 (function(global) {
 
+var _matchesLocalNameOrElement = global.EPUBcfi._matchesLocalNameOrElement;
+
 var init = function($, cfiInstructions, cfiRuntimeErrors) {
     
     if (typeof cfiInstructions === "undefined") {
@@ -152,7 +154,7 @@ var obj = {
                 this.validateStartTextNode(rangeStartElement);
                 // Generate terminating offset and range 1
                 range1OffsetStep = this.createCFITextNodeStep($(rangeStartElement), startOffset, classBlacklist, elementBlacklist, idBlacklist);
-                if($(rangeStartElement).parent().is(commonAncestor)){
+                if ($(rangeStartElement).parent()[0].isSameNode(commonAncestor)) {
                     range1CFI = range1OffsetStep;
                 } else {
                     range1CFI = this.createCFIElementSteps($(rangeStartElement).parent(), commonAncestor, classBlacklist, elementBlacklist, idBlacklist) + range1OffsetStep;    
@@ -166,7 +168,7 @@ var obj = {
                 this.validateStartTextNode(rangeEndElement);
                 // Generate terminating offset and range 2
                 range2OffsetStep = this.createCFITextNodeStep($(rangeEndElement), endOffset, classBlacklist, elementBlacklist, idBlacklist);
-                if($(rangeEndElement).parent().is(commonAncestor)){
+                if ($(rangeEndElement).parent()[0].isSameNode(commonAncestor)) {
                     range2CFI = range2OffsetStep;
                 } else {
                     range2CFI = this.createCFIElementSteps($(rangeEndElement).parent(), commonAncestor, classBlacklist, elementBlacklist, idBlacklist) + range2OffsetStep;    
@@ -449,7 +451,7 @@ var obj = {
         //   Also need to check if the current node is the top-level element. This can occur if the start node is also the
         //   top level element.
         $parentNode = $currNode.parent();
-        if ($parentNode.is(topLevelElement) || $currNode.is(topLevelElement)) {
+        if (_matchesLocalNameOrElement($parentNode[0], topLevelElement) || _matchesLocalNameOrElement($currNode[0], topLevelElement)) {
             
             // If the top level node is a type from which an indirection step, add an indirection step character (!)
             // REFACTORING CANDIDATE: It is possible that this should be changed to: if (topLevelElement = 'package') do

--- a/js/cfi_instructions.js
+++ b/js/cfi_instructions.js
@@ -13,6 +13,8 @@
 
 (function(global) {
 
+var _matchesLocalNameOrElement = global.EPUBcfi._matchesLocalNameOrElement;
+
 var init = function($, cfiRuntimeErrors) {
     
 var obj = {
@@ -61,13 +63,13 @@ var obj = {
 
         // TODO: This check must be expanded to all the different types of indirection step
         // Only expects iframes, at the moment
-        if ($currNode === undefined || !$currNode.is("iframe")) {
+        if ($currNode === undefined || !_matchesLocalNameOrElement($currNode[0], 'iframe')) {
 
             throw cfiRuntimeErrors.NodeTypeError($currNode, "expected an iframe element");
         }
 
         // Check node type; only iframe indirection is handled, at the moment
-        if ($currNode.is("iframe")) {
+        if (_matchesLocalNameOrElement($currNode[0], 'iframe')) {
 
             // Get content
             $contentDocument = $currNode.contents();
@@ -320,7 +322,7 @@ var obj = {
                     // For each type of element
                     $.each(elementBlacklist, function (index, value) {
 
-                        if ($currElement.is(value)) {
+                        if (_matchesLocalNameOrElement($currElement[0], value)) {
                             includeInList = false;
 
                             // Break this loop

--- a/js/cfi_interpreter.js
+++ b/js/cfi_interpreter.js
@@ -13,6 +13,8 @@
 
 (function(global) {
 
+var _matchesLocalNameOrElement = global.EPUBcfi._matchesLocalNameOrElement;
+
 var init = function($, cfiParser, cfiInstructions, cfiRuntimeErrors) {
 
     if (typeof cfiParser === "undefined") {
@@ -424,8 +426,7 @@ var obj = {
             }
 
             // Found the content document href referenced by the spine item
-            if ($currElement.is("itemref")) {
-
+            if (_matchesLocalNameOrElement($currElement[0], "itemref")) {
                 return cfiInstructions.retrieveItemRefHref($currElement, $packageDocument);
             }
         }


### PR DESCRIPTION
Builds upon #40 

This replaces the usage of $element.is( [selector | element] )
The selector type we use  is limited to tag names so checking using domElement.localName should work for this case
Sometimes we check if two elements are the same, or there are code paths were it's not sure if the input is a local name selector string or an element reference. This has been implemented as a helper method.

#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
#40. #39

#### Test cases, sample files
One reproducible way is to load a book with a namespaced root element in the OPF in Readium.