### PR TITLE
[build-tools] Configure the RequireJS optimizer to use a namespace

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -26,7 +26,7 @@ var check = function(cfiParser, cfiInterpreter, cfiInstructions, cfiRuntimeError
 };
 
 
-if (typeof define == 'function' && typeof define.amd == 'object') {
+if (typeof define === 'function' && define.amd) {
     console.log("RequireJS ... index.js");
 
     // For attaching the global window objects

--- a/js/cfi_API.js
+++ b/js/cfi_API.js
@@ -128,7 +128,7 @@ var init = function(cfiParser, cfiInterpreter, cfiInstructions, cfiRuntimeErrors
 
 
 
-if (typeof define == 'function' && typeof define.amd == 'object') {
+if (typeof define === 'function' && define.amd) {
     console.log("RequireJS ... cfi_API");
 
     define(['readium_cfi_js/cfi_parser', './cfi_interpreter', './cfi_instructions', './cfi_runtime_errors', './cfi_generator'],

--- a/js/cfi_generator.js
+++ b/js/cfi_generator.js
@@ -437,7 +437,7 @@ return obj;
 
 
 
-if (typeof define == 'function' && typeof define.amd == 'object') {
+if (typeof define === 'function' && define.amd) {
     console.log("RequireJS ... cfi_generator");
     
     define(['jquery', './cfi_instructions', './cfi_runtime_errors'],

--- a/js/cfi_instructions.js
+++ b/js/cfi_instructions.js
@@ -367,7 +367,7 @@ return obj;
 
 
 
-if (typeof define == 'function' && typeof define.amd == 'object') {
+if (typeof define === 'function' && define.amd) {
     console.log("RequireJS ... cfi_instructions");
     
     define(['jquery', 'underscore', './cfi_runtime_errors'],

--- a/js/cfi_interpreter.js
+++ b/js/cfi_interpreter.js
@@ -445,7 +445,7 @@ return obj;
 
 
 
-if (typeof define == 'function' && typeof define.amd == 'object') {
+if (typeof define === 'function' && define.amd) {
     console.log("RequireJS ... cfi_interpreter");
 
     define(['jquery', 'readium_cfi_js/cfi_parser', './cfi_instructions', './cfi_runtime_errors'],

--- a/js/cfi_runtime_errors.js
+++ b/js/cfi_runtime_errors.js
@@ -93,7 +93,7 @@ CFIAssertionError: function (expectedAssertion, targetElementAssertion, message)
 
 
 
-if (typeof define == 'function' && typeof define.amd == 'object') {
+if (typeof define === 'function' && define.amd) {
     console.log("RequireJS ... cfi_errors");
     
     define([],

--- a/readium-build-tools/RequireJS_config.js
+++ b/readium-build-tools/RequireJS_config.js
@@ -316,7 +316,7 @@ function(thiz){
       }
 */
 
-
+    namespace: '_readium_js', // see http://requirejs.org/docs/faq-optimization.html#namespace
     inlineText: true,
 
     //xhtml: true, //document.createElementNS()


### PR DESCRIPTION
Configure the RequireJS optimizer to namespace the `require` and `define` calls in output bundles

This essentially isolates the use of RequireJS so that Readium could be better integrated with other web pages that don't use RequireJS, or use something else that conflicts with the use of the `require` variable in the global namespace.

One example of this case is with including Hypothes.is in a web page with Readium.
Hypothes.is uses a different module loading library, IIRC browserify. There's a race to define `window.require` between it and what we use, almond.js
