### PR TITLE
Fix a certain DOM range input that results in an incorrect CFI range

### DIFF
--- a/js/cfi_generator.js
+++ b/js/cfi_generator.js
@@ -66,6 +66,7 @@ var obj = {
     },
 
     generateDocumentRangeComponent : function (domRange, classBlacklist, elementBlacklist, idBlacklist) {
+        this._normalizeDomRange(domRange);
 
         var rangeStartElement = domRange.startContainer;
         var startOffset = domRange.startOffset;
@@ -273,6 +274,46 @@ var obj = {
         }
         else if ($($("itemref[idref='" + contentDocumentName + "']", packageDocument)[0]).length === 0) {
             throw new Error("The idref of the content document could not be found in the spine");
+        }
+    },
+
+    _validNodeTypesFilter: function (node) {
+        return node.nodeType === Node.TEXT_NODE || node.nodeType === Node.ELEMENT_NODE;
+    },
+
+    _normalizeDomRange: function (domRange) {
+        var rangeStartNode = domRange.startContainer;
+        var rangeEndNode = domRange.endContainer;
+        var commonAncestorNode = domRange.commonAncestorContainer;
+
+        if (commonAncestorNode.nodeType !== Node.ELEMENT_NODE) {
+            // No need for normalization on ranges where the ancestor is not an element
+            return;
+        }
+
+        if (rangeStartNode.nodeType !== Node.TEXT_NODE && rangeEndNode.nodeType !== Node.TEXT_NODE) {
+            // and one of the start/end nodes must be a text node
+            return;
+        }
+
+        if (rangeStartNode === commonAncestorNode) {
+            var firstChildNode = _.first(_.filter(rangeStartNode.childNodes, this._validNodeTypesFilter));
+            if (firstChildNode) {
+                domRange.setStart(firstChildNode, 0);
+            }
+        }
+
+        if (rangeEndNode === commonAncestorNode) {
+            var lastChildNode = _.last(_.filter(rangeEndNode.childNodes, this._validNodeTypesFilter));
+            if (lastChildNode) {
+                if (lastChildNode.length) {
+                    domRange.setEnd(lastChildNode, lastChildNode.length);
+                } else if (lastChildNode.hasChildNodes()) {
+                    domRange.setEnd(lastChildNode, lastChildNode.childNodes.length);
+                } else {
+                    domRange.setEnd(lastChildNode, 1);
+                }
+            }
         }
     },
 

--- a/tests/spec/models/cfi_generator_spec.js
+++ b/tests/spec/models/cfi_generator_spec.js
@@ -216,6 +216,70 @@ describe("CFI GENERATOR", function () {
             expect(generatedCFI).toEqual("/4/2[startParent]/2");
         });
 
+        it("can generate a range component given a start text node as a text node, and the end node being the parent of that text node", function () {
+
+            var dom =
+                "<html>"
+                +    "<div></div>"
+                +    "<div>"
+                +         "<div id='startParent'>"
+                +             "textnode0"
+                +             "<p id='theParagraph'>textnode1</p>"
+                +             "textnode2"
+                +             "<div></div>"
+                +         "</div>"
+                +     "</div>"
+                +     "<div></div>"
+                + "</html>";
+            var $dom = $((new window.DOMParser).parseFromString(dom, "text/xml"));
+
+            var paragraphElement = $('#theParagraph', $dom)[0];
+            var paragraphTextNode = paragraphElement.childNodes[0];
+
+            // The setup here is a range that fits this profile
+            // - commonAncestorContainer: p#theParagraph
+            // - startContainer: 'textnode1', child of p#theParagraph
+            // - startOffset: 0 (start character offset)
+            // - endContainer: p#theParagraph
+            // - endOffset: 1 (length of p#theParagraph node)
+            // A browser may generate a Range that matches this when a paragraph is fully selected. (seen in MS Edge)
+
+            var generatedCFI = EPUBcfi.Generator.generateRangeComponent(paragraphTextNode, 0, paragraphElement, 1);
+            expect(generatedCFI).toEqual("/4/2[startParent]/2[theParagraph],/1:0,/1:9");
+        });
+
+        it("can generate a range component given a start node that's parent of a text node, and the end node being that text node", function () {
+
+            var dom =
+                "<html>"
+                +    "<div></div>"
+                +    "<div>"
+                +         "<div id='startParent'>"
+                +             "textnode0"
+                +             "<p id='theParagraph'>textnode1</p>"
+                +             "textnode2"
+                +             "<div></div>"
+                +         "</div>"
+                +     "</div>"
+                +     "<div></div>"
+                + "</html>";
+            var $dom = $((new window.DOMParser).parseFromString(dom, "text/xml"));
+
+            var paragraphElement = $('#theParagraph', $dom)[0];
+            var paragraphTextNode = paragraphElement.childNodes[0];
+
+            // The setup here is a range that fits this profile
+            // - commonAncestorContainer: p#theParagraph
+            // - startContainer: p#theParagraph
+            // - startOffset: 0 (start offset of p#theParagraph node length)
+            // - endContainer: 'textnode1', child of `p#theParagraph
+            // - endtOffset: 9 (length of text node data)
+            // A browser may also theoretically generate a Range like this when a paragraph is fully selected.
+
+            var generatedCFI = EPUBcfi.Generator.generateRangeComponent(paragraphElement, 0, paragraphTextNode, paragraphTextNode.length);
+            expect(generatedCFI).toEqual("/4/2[startParent]/2[theParagraph],/1:0,/1:9");
+        });
+
         describe("character offset range CFIs", function () {
 
             it("generates for different start and end nodes", function () {


### PR DESCRIPTION
I came across a DOM range that was generated in MS Edge, the range comes from when you fully select a paragraph with just a single text node, from start to end

Given this HTML doc:
```html
<html>
<head></head>
<body>
  <section>
    <p id='theParagraph'>
      textnode1
    </p>
  </section>
</body>
</html>
```

The range for example:
 - commonAncestorContainer: `p#theParagraph`
 - startContainer: `textnode1`, child of `p#theParagraph`
 - startOffset: 0 (start character offset)
 - endContainer: `p#theParagraph`
 - endOffset: 1 (length of` p#theParagraph` node)

The CFI should be like this:
`/4/2/2[theParagraph],/1:0,/1:9`

But it actually ended up like this:
`/4/2/2[theParagraph],/1:0,/2[theParagraph]`

#### This pull request is Finalized